### PR TITLE
Embedding models

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 on: pull_request
 jobs:
   build:
-    runs-on: [self-hosted, amd64, 2x4]
+    runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,11 @@ jobs:
           ruby-version: ruby
           bundler-cache: true
 
-      - run: free -h
-      - run: bundle exec rake compile
+      - name: Display Memory Usage
+        run: free -h
+
+      - name: Display Disk Space Before Test
+        run: df -h
 
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind
@@ -30,5 +33,8 @@ jobs:
       - name: Display Peak Memory Usage
         run: |
           ms_print massif.out | head -n 30
+
+      - name: Display Disk Space After Test
+        run: df -h
 
       - run: bundle exec yard --fail-on-warning --readme README.md --markup markdown --markup-provider redcarpet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,19 @@ jobs:
             ~/.cargo/git
             tmp
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
           bundler-cache: true
+
       - run: free -h
       - run: bundle exec rake compile
-      - run: bundle exec rake test
-      - run: bundle exec yard --fail-on-warning
+
+      - name: Install Valgrind
+        run: sudo apt-get update && sudo apt-get install -y valgrind
+
+      - name: Run tests with Valgrind
+        run: valgrind --leak-check=full --track-origins=yes bundle exec rake test
+
+      - run: bundle exec yard --fail-on-warning --readme README.md --markup markdown --markup-provider redcarpet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y valgrind
 
       - name: Run tests with Valgrind Massif (Peak Memory)
-        run: valgrind --tool=massif bundle exec rake test
+        run: valgrind --tool=massif --massif-out-file=massif.out bundle exec rake test
+
+      - name: Display Peak Memory Usage
+        run: |
+          ms_print massif.out | head -n 30
 
       - run: bundle exec yard --fail-on-warning --readme README.md --markup markdown --markup-provider redcarpet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build
-on: [push, pull_request]
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest-8-cores

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind
 
-      - name: Run tests with Valgrind
-        run: valgrind --leak-check=full --track-origins=yes bundle exec rake test
+      - name: Run tests with Valgrind Massif (Peak Memory)
+        run: valgrind --tool=massif bundle exec rake test
 
       - run: bundle exec yard --fail-on-warning --readme README.md --markup markdown --markup-provider redcarpet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 on: pull_request
 jobs:
   build:
-    runs-on: ubuntu-latest-m
+    runs-on: red-candle-runner
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: build
 on: pull_request
 jobs:
   build:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: [self-hosted, amd64, 2x4]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           ruby-version: ruby
           bundler-cache: true
+      - run: free -h
       - run: bundle exec rake compile
       - run: bundle exec rake test
       - run: bundle exec yard --fail-on-warning

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ build-iPhoneSimulator/
 /.bundle/
 /vendor/bundle
 /lib/bundler/man/
+/vendor
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ build-iPhoneSimulator/
 /.bundle/
 /vendor/bundle
 /lib/bundler/man/
-/vendor
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "hf-hub",
  "magnus",
  "safetensors 0.3.3",
+ "serde_json",
  "tokenizers",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "half",
  "hf-hub",
  "magnus",
+ "safetensors 0.3.3",
  "tokenizers",
 ]
 
@@ -214,7 +215,7 @@ dependencies = [
  "rand 0.9.1",
  "rand_distr",
  "rayon",
- "safetensors",
+ "safetensors 0.4.5",
  "thiserror 1.0.58",
  "ug",
  "yoke",
@@ -231,7 +232,7 @@ dependencies = [
  "half",
  "num-traits",
  "rayon",
- "safetensors",
+ "safetensors 0.4.5",
  "serde",
  "thiserror 1.0.58",
 ]
@@ -1281,7 +1282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2124,6 +2125,16 @@ checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "safetensors"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93279b86b3de76f820a8854dd06cbc33cfa57a417b19c47f6a25280112fb1df"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "safetensors"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
@@ -2650,7 +2661,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "rayon",
- "safetensors",
+ "safetensors 0.4.5",
  "serde",
  "thiserror 1.0.58",
  "tracing",

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ gem "rake-compiler"
 
 gem "yard", require: false
 gem "yard-rustdoc", require: false
+
+gem "redcarpet", "~> 3.6"

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ model = Candle::Model.new
 embedding = model.embedding("Hi there!")
 
 # Specify a different model type
-model = Candle::Model.new2(
-  "sentence-transformers/all-MiniLM-L6-v2",  # model path
-  "sentence-transformers/all-MiniLM-L6-v2",  # tokenizer path
-  nil,                                       # device (nil = CPU)
-  Candle::ModelType::STANDARD_BERT           # model type
+model = Candle::Model.new(
+  model_path: "sentence-transformers/all-MiniLM-L6-v2",
+  tokenizer_path: "sentence-transformers/all-MiniLM-L6-v2",
+  device: nil,  # nil = CPU
+  model_type: Candle::ModelType::STANDARD_BERT
 )
 embedding = model.embedding("Hi there!")
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build](https://github.com/assaydepot/red-candle/actions/workflows/build.yml/badge.svg)](https://github.com/assaydepot/red-candle/actions/workflows/build.yml)
 [![Gem Version](https://badge.fury.io/rb/red-candle.svg)](https://badge.fury.io/rb/red-candle)
 
-🕯️ [candle](https://github.com/huggingface/candle) - Minimalist ML framework - for Ruby
+ [candle](https://github.com/huggingface/candle) - Minimalist ML framework - for Ruby
 
 ## Usage
 
@@ -35,14 +35,34 @@ model = Candle::Model.new(
 embedding = model.embedding("Hi there!")
 ```
 
+## ⚠️ Model Format Requirement: Safetensors Only (GGML for Llama)
+
+Red-Candle **only supports embedding models that provide their weights in the [safetensors](https://github.com/huggingface/safetensors) format** (i.e., the model repo must contain a `model.safetensors` file), **except for Llama models, which must provide a `model.ggml` file**. If the model repo does not provide the required file, loading will fail with a clear error. Most official BERT and DistilBERT models do **not** provide safetensors; many Sentence Transformers and JinaBERT models do. Llama models are only supported in GGML format (not safetensors or bin).
+
+**If you encounter an error like:**
+
+```
+RuntimeError: model.safetensors not found after download. Only safetensors models are supported. Please ensure your model repo contains model.safetensors.
+```
+
+or
+
+```
+RuntimeError: model.ggml not found after download. Only GGML format is supported for Llama models. Please ensure your model repo contains model.ggml.
+```
+
+this means the selected model is not compatible. Please choose a model repo that provides the required file.
+
 ## Supported Embedding Models
 
 Red-Candle supports the following embedding model types from Hugging Face:
 
-1. `Candle::ModelType::JINA_BERT` - Jina BERT models (e.g., `jinaai/jina-embeddings-v2-base-en`)
-2. `Candle::ModelType::STANDARD_BERT` - Standard BERT models (e.g., `sentence-transformers/all-MiniLM-L6-v2`)
-3. `Candle::ModelType::SENTIMENT` - Sentiment models (e.g., `distilbert-base-uncased-finetuned-sst-2-english`)
-4. `Candle::ModelType::LLAMA` - Llama models (e.g., `meta-llama/Llama-2-7b` - requires Hugging Face token)
+1. `Candle::ModelType::JINA_BERT` - Jina BERT models (e.g., `jinaai/jina-embeddings-v2-base-en`) (**safetensors required**)
+2. `Candle::ModelType::STANDARD_BERT` - Standard BERT models (e.g., `sentence-transformers/all-MiniLM-L6-v2`) (**safetensors required**)
+3. `Candle::ModelType::SENTIMENT` - Sentiment models (e.g., `distilbert-base-uncased-finetuned-sst-2-english`) (**safetensors required**)
+4. `Candle::ModelType::LLAMA` - Llama models (e.g., `meta-llama/Llama-2-7b` - requires Hugging Face token, **GGML required**)
+
+> **Note:** Most official BERT and DistilBERT models do _not_ provide safetensors. Llama models must be in GGML format. Please check the model repo before use.
 
 You can get a list of all supported model types and suggested models paths:
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,39 @@ x = x.reshape([3, 2])
 
 ```ruby
 require 'candle'
+
+# Default model (JinaBERT)
 model = Candle::Model.new
+embedding = model.embedding("Hi there!")
+
+# Specify a different model type
+model = Candle::Model.new2(
+  "sentence-transformers/all-MiniLM-L6-v2",  # model path
+  "sentence-transformers/all-MiniLM-L6-v2",  # tokenizer path
+  nil,                                       # device (nil = CPU)
+  Candle::ModelType::STANDARD_BERT           # model type
+)
 embedding = model.embedding("Hi there!")
 ```
 
+## Supported Embedding Models
+
+Red-Candle supports the following embedding model types from Hugging Face:
+
+1. `Candle::ModelType::JINA_BERT` - Jina BERT models (e.g., `jinaai/jina-embeddings-v2-base-en`)
+2. `Candle::ModelType::STANDARD_BERT` - Standard BERT models (e.g., `sentence-transformers/all-MiniLM-L6-v2`)
+3. `Candle::ModelType::SENTIMENT` - Sentiment models (e.g., `distilbert-base-uncased-finetuned-sst-2-english`)
+4. `Candle::ModelType::LLAMA` - Llama models (e.g., `meta-llama/Llama-2-7b` - requires Hugging Face token)
+
+You can get a list of all supported model types and suggested models paths:
+
+```ruby
+Candle::ModelType.all  # Returns all supported model types
+Candle::ModelType.suggested_model_paths  # Returns hash of suggested models for each type
+```
+
 ## A note on memory usage
-The `Candle::Model` defaults to the `jinaai/jina-embeddings-v2-base-en` model with the `sentence-transformers/all-MiniLM-L6-v2` tokenizer (both from [HuggingFace](https://huggingface.co)). With this configuration the model takes a little more than 3GB of memory running on my Mac. The memory stays with the instantiated `Candle::Model` class, if you instantiate more than one, you'll use more memory. Likewise, if you let it go out of scope and call the garbage collector, you'll free the memory. For example:
+The default model (`jinaai/jina-embeddings-v2-base-en` with the `sentence-transformers/all-MiniLM-L6-v2` tokenizer, both from [HuggingFace](https://huggingface.co)) takes a little more than 3GB of memory running on a Mac. The memory stays with the instantiated `Candle::Model` class, if you instantiate more than one, you'll use more memory. Likewise, if you let it go out of scope and call the garbage collector, you'll free the memory. For example:
 
 ```ruby
 > require 'candle'

--- a/README.md
+++ b/README.md
@@ -35,20 +35,14 @@ model = Candle::Model.new(
 embedding = model.embedding("Hi there!")
 ```
 
-## ⚠️ Model Format Requirement: Safetensors Only (GGML for Llama)
+## ⚠️ Model Format Requirement: Safetensors Only
 
-Red-Candle **only supports embedding models that provide their weights in the [safetensors](https://github.com/huggingface/safetensors) format** (i.e., the model repo must contain a `model.safetensors` file), **except for Llama models, which must provide a `model.ggml` file**. If the model repo does not provide the required file, loading will fail with a clear error. Most official BERT and DistilBERT models do **not** provide safetensors; many Sentence Transformers and JinaBERT models do. Llama models are only supported in GGML format (not safetensors or bin).
+Red-Candle **only supports embedding models that provide their weights in the [safetensors](https://github.com/huggingface/safetensors) format** (i.e., the model repo must contain a `model.safetensors` file). If the model repo does not provide the required file, loading will fail with a clear error. Most official BERT and DistilBERT models do **not** provide safetensors; many Sentence Transformers and JinaBERT models do.
 
 **If you encounter an error like:**
 
 ```
 RuntimeError: model.safetensors not found after download. Only safetensors models are supported. Please ensure your model repo contains model.safetensors.
-```
-
-or
-
-```
-RuntimeError: model.ggml not found after download. Only GGML format is supported for Llama models. Please ensure your model repo contains model.ggml.
 ```
 
 this means the selected model is not compatible. Please choose a model repo that provides the required file.
@@ -60,9 +54,8 @@ Red-Candle supports the following embedding model types from Hugging Face:
 1. `Candle::ModelType::JINA_BERT` - Jina BERT models (e.g., `jinaai/jina-embeddings-v2-base-en`) (**safetensors required**)
 2. `Candle::ModelType::STANDARD_BERT` - Standard BERT models (e.g., `sentence-transformers/all-MiniLM-L6-v2`) (**safetensors required**)
 3. `Candle::ModelType::DISTILBERT` - DistilBERT models (e.g., `distilbert-base-uncased-finetuned-sst-2-english`) (**safetensors required**)
-4. `Candle::ModelType::LLAMA` - Llama models (e.g., `meta-llama/Llama-2-7b` - requires Hugging Face token, **GGML required**)
 
-> **Note:** Most official BERT and DistilBERT models do _not_ provide safetensors. Llama models must be in GGML format. Please check the model repo before use.
+> **Note:** Most official BERT and DistilBERT models do _not_ provide safetensors. Please check the model repo before use.
 
 You can get a list of all supported model types and suggested models paths:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Red-Candle supports the following embedding model types from Hugging Face:
 
 1. `Candle::ModelType::JINA_BERT` - Jina BERT models (e.g., `jinaai/jina-embeddings-v2-base-en`) (**safetensors required**)
 2. `Candle::ModelType::STANDARD_BERT` - Standard BERT models (e.g., `sentence-transformers/all-MiniLM-L6-v2`) (**safetensors required**)
-3. `Candle::ModelType::SENTIMENT` - Sentiment models (e.g., `distilbert-base-uncased-finetuned-sst-2-english`) (**safetensors required**)
+3. `Candle::ModelType::DISTILBERT` - DistilBERT models (e.g., `distilbert-base-uncased-finetuned-sst-2-english`) (**safetensors required**)
 4. `Candle::ModelType::LLAMA` - Llama models (e.g., `meta-llama/Llama-2-7b` - requires Hugging Face token, **GGML required**)
 
 > **Note:** Most official BERT and DistilBERT models do _not_ provide safetensors. Llama models must be in GGML format. Please check the model repo before use.

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "candle"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+# Check if Rust is installed
+if ! command -v cargo &> /dev/null
+then
+    echo "Rust is not installed. Please install Rust: https://www.rust-lang.org/tools/install"
+    exit 1
+fi
+
+# Install Ruby dependencies
+bundle install
+
+# Build Rust extension
+bundle exec rake compile

--- a/ext/candle/Cargo.toml
+++ b/ext/candle/Cargo.toml
@@ -15,6 +15,7 @@ hf-hub = "0.4.2"
 half = "2.6.0"
 magnus = "0.7.1"
 safetensors = "0.3"
+serde_json = "1.0"
 
 [features]
 mkl = []

--- a/ext/candle/Cargo.toml
+++ b/ext/candle/Cargo.toml
@@ -14,6 +14,7 @@ tokenizers = { version = "0.21.1", default-features = true, features = ["fancy-r
 hf-hub = "0.4.2"
 half = "2.6.0"
 magnus = "0.7.1"
+safetensors = "0.3"
 
 [features]
 mkl = []

--- a/ext/candle/src/lib.rs
+++ b/ext/candle/src/lib.rs
@@ -94,7 +94,7 @@ fn init(ruby: &Ruby) -> RbResult<()> {
     rb_qtensor.define_method("dequantize", method!(RbQTensor::dequantize, 0))?;
 
     let rb_model = rb_candle.define_class("Model", Ruby::class_object(ruby))?;
-    rb_model.define_singleton_method("_create", function!(RbModel::new, 4))?;
+    rb_model.define_singleton_method("_create", function!(RbModel::new, 5))?;
     rb_model.define_method("embedding", method!(RbModel::embedding, 1))?;
     rb_model.define_method("model_type", method!(RbModel::model_type, 0))?;
     rb_model.define_method("to_s", method!(RbModel::__str__, 0))?;

--- a/ext/candle/src/lib.rs
+++ b/ext/candle/src/lib.rs
@@ -94,7 +94,10 @@ fn init(ruby: &Ruby) -> RbResult<()> {
     rb_qtensor.define_method("dequantize", method!(RbQTensor::dequantize, 0))?;
 
     let rb_model = rb_candle.define_class("Model", Ruby::class_object(ruby))?;
-    rb_model.define_singleton_method("_create", function!(RbModel::new, 5))?;
+    rb_model.define_singleton_method(
+        "_create",
+        function!(RbModel::new, 5),
+    )?;
     rb_model.define_method("embedding", method!(RbModel::embedding, 1))?;
     rb_model.define_method("model_type", method!(RbModel::model_type, 0))?;
     rb_model.define_method("to_s", method!(RbModel::__str__, 0))?;

--- a/ext/candle/src/lib.rs
+++ b/ext/candle/src/lib.rs
@@ -99,6 +99,8 @@ fn init(ruby: &Ruby) -> RbResult<()> {
         function!(RbModel::new, 5),
     )?;
     rb_model.define_method("embedding", method!(RbModel::embedding, 1))?;
+    rb_model.define_method("embeddings", method!(RbModel::embeddings, 1))?;
+    rb_model.define_method("pool_and_normalize_embedding", method!(RbModel::pool_and_normalize_embedding, 1))?;
     rb_model.define_method("model_type", method!(RbModel::model_type, 0))?;
     rb_model.define_method("to_s", method!(RbModel::__str__, 0))?;
     rb_model.define_method("inspect", method!(RbModel::__repr__, 0))?;

--- a/ext/candle/src/lib.rs
+++ b/ext/candle/src/lib.rs
@@ -94,8 +94,9 @@ fn init(ruby: &Ruby) -> RbResult<()> {
     rb_qtensor.define_method("dequantize", method!(RbQTensor::dequantize, 0))?;
 
     let rb_model = rb_candle.define_class("Model", Ruby::class_object(ruby))?;
-    rb_model.define_singleton_method("new", function!(RbModel::new, 0))?;
+    rb_model.define_method("initialize", function!(RbModel::new, 4))?;
     rb_model.define_method("embedding", method!(RbModel::embedding, 1))?;
+    rb_model.define_method("model_type", method!(RbModel::model_type, 0))?;
     rb_model.define_method("to_s", method!(RbModel::__str__, 0))?;
     rb_model.define_method("inspect", method!(RbModel::__repr__, 0))?;
 

--- a/ext/candle/src/lib.rs
+++ b/ext/candle/src/lib.rs
@@ -94,7 +94,7 @@ fn init(ruby: &Ruby) -> RbResult<()> {
     rb_qtensor.define_method("dequantize", method!(RbQTensor::dequantize, 0))?;
 
     let rb_model = rb_candle.define_class("Model", Ruby::class_object(ruby))?;
-    rb_model.define_method("initialize", function!(RbModel::new, 4))?;
+    rb_model.define_singleton_method("_create", function!(RbModel::new, 4))?;
     rb_model.define_method("embedding", method!(RbModel::embedding, 1))?;
     rb_model.define_method("model_type", method!(RbModel::model_type, 0))?;
     rb_model.define_method("to_s", method!(RbModel::__str__, 0))?;

--- a/ext/candle/src/lib.rs
+++ b/ext/candle/src/lib.rs
@@ -98,7 +98,8 @@ fn init(ruby: &Ruby) -> RbResult<()> {
         "_create",
         function!(RbModel::new, 5),
     )?;
-    rb_model.define_method("embedding", method!(RbModel::embedding, 1))?;
+    // Expose embedding with an optional pooling_method argument (default: "pooled")
+    rb_model.define_method("_embedding", method!(RbModel::embedding, 2))?;
     rb_model.define_method("embeddings", method!(RbModel::embeddings, 1))?;
     rb_model.define_method("pool_embedding", method!(RbModel::pool_embedding, 1))?;
     rb_model.define_method("pool_and_normalize_embedding", method!(RbModel::pool_and_normalize_embedding, 1))?;

--- a/ext/candle/src/lib.rs
+++ b/ext/candle/src/lib.rs
@@ -27,7 +27,10 @@ fn init(ruby: &Ruby) -> RbResult<()> {
     rb_tensor.define_method("cos", method!(RbTensor::cos, 0))?;
     rb_tensor.define_method("log", method!(RbTensor::log, 0))?;
     rb_tensor.define_method("sqr", method!(RbTensor::sqr, 0))?;
+    rb_tensor.define_method("mean", method!(RbTensor::mean, 1))?;
+    rb_tensor.define_method("sum", method!(RbTensor::sum, 1))?;
     rb_tensor.define_method("sqrt", method!(RbTensor::sqrt, 0))?;
+    rb_tensor.define_method("/", method!(RbTensor::__truediv__, 1))?; // Accepts Tensor, Float, or Integer
     rb_tensor.define_method("recip", method!(RbTensor::recip, 0))?;
     rb_tensor.define_method("exp", method!(RbTensor::exp, 0))?;
     rb_tensor.define_method("powf", method!(RbTensor::powf, 1))?;

--- a/ext/candle/src/lib.rs
+++ b/ext/candle/src/lib.rs
@@ -100,7 +100,9 @@ fn init(ruby: &Ruby) -> RbResult<()> {
     )?;
     rb_model.define_method("embedding", method!(RbModel::embedding, 1))?;
     rb_model.define_method("embeddings", method!(RbModel::embeddings, 1))?;
+    rb_model.define_method("pool_embedding", method!(RbModel::pool_embedding, 1))?;
     rb_model.define_method("pool_and_normalize_embedding", method!(RbModel::pool_and_normalize_embedding, 1))?;
+    rb_model.define_method("pool_cls_embedding", method!(RbModel::pool_cls_embedding, 1))?;
     rb_model.define_method("model_type", method!(RbModel::model_type, 0))?;
     rb_model.define_method("to_s", method!(RbModel::__str__, 0))?;
     rb_model.define_method("inspect", method!(RbModel::__repr__, 0))?;

--- a/ext/candle/src/model/rb_model.rs
+++ b/ext/candle/src/model/rb_model.rs
@@ -266,10 +266,15 @@ impl RbModel {
         Ok(tokenizer)
     }
 
-    fn pooled_normalized_embedding(result: &Tensor) -> Result<Tensor, Error> {
+    fn pooled_embedding(result: &Tensor) -> Result<Tensor, Error> {
         let (_n_sentence, n_tokens, _hidden_size) = result.dims3().map_err(wrap_candle_err)?;
         let sum = result.sum(1).map_err(wrap_candle_err)?;
         let mean = (sum / (n_tokens as f64)).map_err(wrap_candle_err)?;
+        Ok(mean)
+    }
+
+    fn pooled_normalized_embedding(result: &Tensor) -> Result<Tensor, Error> {
+        let mean = Self::pooled_embedding(result)?;
         let norm = Self::normalize_l2(&mean).map_err(wrap_candle_err)?;
         Ok(norm)
     }

--- a/ext/candle/src/model/rb_model.rs
+++ b/ext/candle/src/model/rb_model.rs
@@ -9,7 +9,7 @@ use crate::model::{
     rb_tensor::RbTensor,
 };
 use crate::model::rb_device::RbDevice;
-use candle_core::{DType, Device, Module, Tensor, quantized::ggml_file::Content};
+use candle_core::{DType, Device, Module, Tensor};
 use safetensors::tensor::SafeTensors;
 use candle_nn::VarBuilder;
 use candle_transformers::models::{
@@ -19,8 +19,6 @@ use candle_transformers::models::{
 };
 use magnus::Error;
 use crate::model::RbResult;
-use std::sync::Arc;
-use std::fs::File;
 use std::path::Path;
 use tokenizers::Tokenizer;
 use serde_json;

--- a/ext/candle/src/model/rb_model.rs
+++ b/ext/candle/src/model/rb_model.rs
@@ -80,10 +80,13 @@ pub struct RbModelInner {
 
 impl RbModel {
     pub fn new(model_path: Option<String>, tokenizer_path: Option<String>, device: Option<RbDevice>, model_type: Option<String>, embedding_size: Option<usize>) -> RbResult<Self> {
+        println!("Initializing model for {:?} with embedding size {:?}, model path {:?}, tokenizer path {:?}, device {:?}", model_type, embedding_size, model_path, tokenizer_path, device);
         let device = device.unwrap_or(RbDevice::Cpu).as_device()?;
+        println!("Using device: {:?}", device);
         let model_type = model_type
             .and_then(|mt| ModelType::from_string(&mt))
             .unwrap_or(ModelType::JinaBert);
+        println!("Using model type: {:?}", model_type);
         Ok(RbModel(RbModelInner {
             device: device.clone(),
             model_path: model_path.clone(),
@@ -138,9 +141,14 @@ impl RbModel {
 
     /// Infers and validates the embedding size from a safetensors file
     fn resolve_embedding_size(model_path: &Path, embedding_size: Option<usize>) -> Result<usize, magnus::Error> {
+        println!("Resolving embedding size for {:?} with embedding size {:?}", model_path, embedding_size);
         match embedding_size {
-            Some(user_dim) => Ok(user_dim),
+            Some(user_dim) => {
+                println!("Using user-specified embedding size: {}", user_dim);
+                Ok(user_dim)
+            },
             None => {
+                println!("Inferring embedding size from model file");
                 let inferred_emb_dim = match SafeTensors::deserialize(&std::fs::read(model_path).map_err(|e| wrap_std_err(Box::new(e)))?) {
                     Ok(st) => {
                         if let Some(tensor) = st.tensor("embeddings.word_embeddings.weight").ok() {
@@ -156,9 +164,13 @@ impl RbModel {
     }
 
     fn build_model(model_path: &Path, device: Device, model_type: ModelType, embedding_size: Option<usize>) -> RbResult<ModelVariant> {
+        println!("Building model for {:?} with embedding size {:?}, model path {:?}, device {:?}", model_type, embedding_size, model_path, device);
         use hf_hub::{api::sync::Api, Repo, RepoType};
+        println!("Fetching model from Hugging Face 1");
         let api = Api::new().map_err(wrap_hf_err)?;
+        println!("Fetching model from Hugging Face 2");
         let repo = Repo::new(model_path.to_str().unwrap().to_string(), RepoType::Model);
+        println!("Fetching model from Hugging Face 3");
         match model_type {
             ModelType::JinaBert => {
                 let model_path = api.repo(repo).get("model.safetensors").map_err(wrap_hf_err)?;

--- a/ext/candle/src/model/rb_model.rs
+++ b/ext/candle/src/model/rb_model.rs
@@ -17,6 +17,7 @@ use candle_transformers::models::{
 };
 use magnus::Error;
 use crate::model::RbResult;
+use crate::model::rb_device::RbDevice;
 use std::sync::Arc;
 use std::fs::File;
 use tokenizers::Tokenizer;
@@ -70,12 +71,8 @@ pub struct RbModelInner {
 }
 
 impl RbModel {
-    pub fn new() -> RbResult<Self> {
-        Self::new2(Some("jinaai/jina-embeddings-v2-base-en".to_string()), Some("sentence-transformers/all-MiniLM-L6-v2".to_string()), Some(Device::Cpu), Some("jina_bert".to_string()))
-    }
-
-    pub fn new2(model_path: Option<String>, tokenizer_path: Option<String>, device: Option<Device>, model_type: Option<String>) -> RbResult<Self> {
-        let device = device.unwrap_or(Device::Cpu);
+    pub fn new(model_path: Option<String>, tokenizer_path: Option<String>, device: Option<RbDevice>, model_type: Option<String>) -> RbResult<Self> {
+        let device = device.unwrap_or(RbDevice::Cpu).as_device()?;
         let model_type = model_type
             .and_then(|mt| ModelType::from_string(&mt))
             .unwrap_or(ModelType::JinaBert);

--- a/ext/candle/src/model/rb_tensor.rs
+++ b/ext/candle/src/model/rb_tensor.rs
@@ -249,7 +249,7 @@ impl RbTensor {
     /// @param rhs [Candle::Tensor, Float, or Integer]
     /// @return [Candle::Tensor]
     pub fn __truediv__(&self, rhs: magnus::Value) -> RbResult<Self> {
-        use magnus::{Float, Integer, TryConvert};
+        use magnus::TryConvert;
         if let Ok(tensor) = <&RbTensor>::try_convert(rhs) {
             Ok(Self(self.0.broadcast_div(&tensor.0).map_err(wrap_candle_err)?))
         } else if let Ok(f) = <f64>::try_convert(rhs) {

--- a/lib/candle.rb
+++ b/lib/candle.rb
@@ -1,2 +1,3 @@
 require_relative "candle/candle"
 require_relative "candle/tensor"
+require_relative "candle/model_type"

--- a/lib/candle.rb
+++ b/lib/candle.rb
@@ -1,3 +1,4 @@
 require_relative "candle/candle"
 require_relative "candle/tensor"
 require_relative "candle/model_type"
+require_relative "candle/model"

--- a/lib/candle/model.rb
+++ b/lib/candle/model.rb
@@ -14,12 +14,14 @@ module Candle
     # @param tokenizer_path [String, nil] The path to the tokenizer on Hugging Face
     # @param device [Candle::Device, nil] The device to use for computation (nil = CPU)
     # @param model_type [String, nil] The type of model to use
+    # @param embedding_size [Integer, nil] Override for the embedding size (optional)
     def self.new(model_path: DEFAULT_MODEL_PATH,
       tokenizer_path: DEFAULT_TOKENIZER_PATH,
       device: nil,
-      model_type: DEFAULT_MODEL_TYPE)
-      # Call the Rust-defined factory method
-      _create(model_path, tokenizer_path, device, model_type)
+      model_type: DEFAULT_MODEL_TYPE,
+      embedding_size: nil)
+      # Call the Rust-defined factory method (embedding_size passed through)
+      _create(model_path, tokenizer_path, device, model_type, embedding_size)
     end
   end
 end

--- a/lib/candle/model.rb
+++ b/lib/candle/model.rb
@@ -1,0 +1,25 @@
+module Candle
+  class Model
+    # Default model path for Jina BERT embedding model
+    DEFAULT_MODEL_PATH = "jinaai/jina-embeddings-v2-base-en"
+    
+    # Default tokenizer path that works well with the default model
+    DEFAULT_TOKENIZER_PATH = "sentence-transformers/all-MiniLM-L6-v2"
+    
+    # Default model type
+    DEFAULT_MODEL_TYPE = "jina_bert"
+    
+    # Constructor for creating a new Model with optional parameters
+    # @param model_path [String, nil] The path to the model on Hugging Face
+    # @param tokenizer_path [String, nil] The path to the tokenizer on Hugging Face
+    # @param device [Candle::Device, nil] The device to use for computation (nil = CPU)
+    # @param model_type [String, nil] The type of model to use
+    def self.new(model_path: DEFAULT_MODEL_PATH,
+      tokenizer_path: DEFAULT_TOKENIZER_PATH,
+      device: nil,
+      model_type: DEFAULT_MODEL_TYPE)
+      # Call the original Rust-defined `new`
+      super(model_path, tokenizer_path, device, model_type)
+    end
+  end
+end

--- a/lib/candle/model.rb
+++ b/lib/candle/model.rb
@@ -20,7 +20,6 @@ module Candle
       device: nil,
       model_type: DEFAULT_MODEL_TYPE,
       embedding_size: nil)
-      # Call the Rust-defined factory method (embedding_size passed through)
       _create(model_path, tokenizer_path, device, model_type, embedding_size)
     end
   end

--- a/lib/candle/model.rb
+++ b/lib/candle/model.rb
@@ -18,8 +18,8 @@ module Candle
       tokenizer_path: DEFAULT_TOKENIZER_PATH,
       device: nil,
       model_type: DEFAULT_MODEL_TYPE)
-      # Call the original Rust-defined `new`
-      super(model_path, tokenizer_path, device, model_type)
+      # Call the Rust-defined factory method
+      _create(model_path, tokenizer_path, device, model_type)
     end
   end
 end

--- a/lib/candle/model.rb
+++ b/lib/candle/model.rb
@@ -22,5 +22,11 @@ module Candle
       embedding_size: nil)
       _create(model_path, tokenizer_path, device, model_type, embedding_size)
     end
+    # Returns the embedding for a string using the specified pooling method.
+    # @param str [String] The input text
+    # @param pooling_method [String] Pooling method: "pooled", "pooled_normalized", or "cls". Default: "pooled"
+    def embedding(str, pooling_method = "pooled")
+      _embedding(str, pooling_method)
+    end
   end
 end

--- a/lib/candle/model_type.rb
+++ b/lib/candle/model_type.rb
@@ -1,0 +1,31 @@
+module Candle
+  # Enum for the supported embedding model types
+  module ModelType
+    # Jina Bert embedding models (e.g., jina-embeddings-v2-base-en)
+    JINA_BERT = "jina_bert"
+    
+    # Standard BERT embedding models (e.g., bert-base-uncased)
+    STANDARD_BERT = "standard_bert"
+    
+    # Sentiment models which can be used for embeddings
+    SENTIMENT = "sentiment"
+    
+    # Llama models which can be used for embeddings
+    LLAMA = "llama"
+    
+    # Returns a list of all supported model types
+    def self.all
+      [JINA_BERT, STANDARD_BERT, SENTIMENT, LLAMA]
+    end
+    
+    # Returns suggested model paths for each model type
+    def self.suggested_model_paths
+      {
+        JINA_BERT => "jinaai/jina-embeddings-v2-base-en",
+        STANDARD_BERT => "sentence-transformers/all-MiniLM-L6-v2",
+        SENTIMENT => "distilbert-base-uncased-finetuned-sst-2-english",
+        LLAMA => "meta-llama/Llama-2-7b" # Requires Hugging Face token
+      }
+    end
+  end
+end

--- a/lib/candle/model_type.rb
+++ b/lib/candle/model_type.rb
@@ -24,7 +24,7 @@ module Candle
         JINA_BERT => "jinaai/jina-embeddings-v2-base-en",
         STANDARD_BERT => "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext",
         MINILM => "sentence-transformers/all-MiniLM-L6-v2",
-        DISTILBERT => "distilbert-base-uncased-finetuned-sst-2-english",
+        DISTILBERT => "scientistcom/distilbert-base-uncased-finetuned-sst-2-english",
       }
     end
   end

--- a/lib/candle/model_type.rb
+++ b/lib/candle/model_type.rb
@@ -7,6 +7,9 @@ module Candle
     # Standard BERT embedding models (e.g., bert-base-uncased)
     STANDARD_BERT = "standard_bert"
     
+    # MiniLM embedding models (e.g., all-MiniLM-L6-v2)
+    MINILM = "minilm"
+    
     # Sentiment models which can be used for embeddings
     SENTIMENT = "sentiment"
     
@@ -15,14 +18,15 @@ module Candle
     
     # Returns a list of all supported model types
     def self.all
-      [JINA_BERT, STANDARD_BERT, SENTIMENT, LLAMA]
+      [JINA_BERT, STANDARD_BERT, MINILM, SENTIMENT, LLAMA]
     end
     
     # Returns suggested model paths for each model type
     def self.suggested_model_paths
       {
         JINA_BERT => "jinaai/jina-embeddings-v2-base-en",
-        STANDARD_BERT => "sentence-transformers/all-MiniLM-L6-v2",
+        STANDARD_BERT => "bert-base-uncased",
+        MINILM => "sentence-transformers/all-MiniLM-L6-v2",
         SENTIMENT => "distilbert-base-uncased-finetuned-sst-2-english",
         LLAMA => "meta-llama/Llama-2-7b" # Requires Hugging Face token
       }

--- a/lib/candle/model_type.rb
+++ b/lib/candle/model_type.rb
@@ -13,12 +13,9 @@ module Candle
     # DistilBERT models which can be used for embeddings
     DISTILBERT = "distilbert"
     
-    # Llama models which can be used for embeddings
-    LLAMA = "llama"
-    
     # Returns a list of all supported model types
     def self.all
-      [JINA_BERT, STANDARD_BERT, DISTILBERT, MINILM, LLAMA]
+      [JINA_BERT, STANDARD_BERT, DISTILBERT, MINILM]
     end
     
     # Returns suggested model paths for each model type
@@ -28,7 +25,6 @@ module Candle
         STANDARD_BERT => "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext",
         MINILM => "sentence-transformers/all-MiniLM-L6-v2",
         DISTILBERT => "distilbert-base-uncased-finetuned-sst-2-english",
-        LLAMA => "meta-llama/Llama-2-7b" # Requires Hugging Face token
       }
     end
   end

--- a/lib/candle/model_type.rb
+++ b/lib/candle/model_type.rb
@@ -25,7 +25,7 @@ module Candle
     def self.suggested_model_paths
       {
         JINA_BERT => "jinaai/jina-embeddings-v2-base-en",
-        STANDARD_BERT => "google-bert/bert-base-uncased",
+        STANDARD_BERT => "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext",
         MINILM => "sentence-transformers/all-MiniLM-L6-v2",
         SENTIMENT => "distilbert-base-uncased-finetuned-sst-2-english",
         LLAMA => "meta-llama/Llama-2-7b" # Requires Hugging Face token

--- a/lib/candle/model_type.rb
+++ b/lib/candle/model_type.rb
@@ -10,15 +10,15 @@ module Candle
     # MiniLM embedding models (e.g., all-MiniLM-L6-v2)
     MINILM = "minilm"
     
-    # Sentiment models which can be used for embeddings
-    SENTIMENT = "sentiment"
+    # DistilBERT models which can be used for embeddings
+    DISTILBERT = "distilbert"
     
     # Llama models which can be used for embeddings
     LLAMA = "llama"
     
     # Returns a list of all supported model types
     def self.all
-      [JINA_BERT, STANDARD_BERT, MINILM, SENTIMENT, LLAMA]
+      [JINA_BERT, STANDARD_BERT, DISTILBERT, MINILM, LLAMA]
     end
     
     # Returns suggested model paths for each model type
@@ -27,7 +27,7 @@ module Candle
         JINA_BERT => "jinaai/jina-embeddings-v2-base-en",
         STANDARD_BERT => "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext",
         MINILM => "sentence-transformers/all-MiniLM-L6-v2",
-        SENTIMENT => "distilbert-base-uncased-finetuned-sst-2-english",
+        DISTILBERT => "distilbert-base-uncased-finetuned-sst-2-english",
         LLAMA => "meta-llama/Llama-2-7b" # Requires Hugging Face token
       }
     end

--- a/lib/candle/model_type.rb
+++ b/lib/candle/model_type.rb
@@ -25,7 +25,7 @@ module Candle
     def self.suggested_model_paths
       {
         JINA_BERT => "jinaai/jina-embeddings-v2-base-en",
-        STANDARD_BERT => "bert-base-uncased",
+        STANDARD_BERT => "google-bert/bert-base-uncased",
         MINILM => "sentence-transformers/all-MiniLM-L6-v2",
         SENTIMENT => "distilbert-base-uncased-finetuned-sst-2-english",
         LLAMA => "meta-llama/Llama-2-7b" # Requires Hugging Face token

--- a/test/model_pooling_test.rb
+++ b/test/model_pooling_test.rb
@@ -1,0 +1,47 @@
+require_relative "test_helper"
+
+class ModelPoolingTest < Minitest::Test
+  def setup
+    @model = Candle::Model.new
+    @string = "The quick brown fox jumps over the lazy dog."
+    @embeddings = @model.embeddings(@string)
+  end
+
+  def test_pool_embedding_matches_manual
+    pooled_ruby = @model.pool_embedding(@embeddings)
+    # Manually pool by averaging over sequence dimension (1)
+    pooled_manual = @embeddings.mean(1)
+    assert_in_delta pooled_ruby.first.to_a[0], pooled_manual.first.to_a[0], 1e-5
+  end
+
+  def test_pool_and_normalize_embedding_matches_manual
+    pooled_norm_ruby = @model.pool_and_normalize_embedding(@embeddings)
+    # Manually pool and then normalize
+    pooled_manual = @embeddings.mean(1)
+    norm = pooled_manual / Math.sqrt(pooled_manual.sqr.sum(1).values.first)
+    assert_in_delta pooled_norm_ruby.first.to_a[0], norm.first.to_a[0], 1e-3
+  end
+
+  def test_pool_cls_embedding
+    cls_ruby = @model.pool_cls_embedding(@embeddings)
+    # Manually extract CLS token (index 0)
+    # For shape [batch, seq, hidden], get first token of first batch
+    cls_manual = @embeddings.get(0).get(0)
+    assert_in_delta cls_ruby.first.to_a[0], cls_manual.to_a[0], 1e-5
+  end
+
+  def test_embedding_calls_correct_pooling
+    pooled = @model.embedding(@string, "pooled")
+    pooled_norm = @model.embedding(@string, "pooled_normalized")
+    cls = @model.embedding(@string, "cls")
+    refute_equal pooled.first.to_a, pooled_norm.first.to_a
+    refute_equal pooled.first.to_a, cls.first.to_a
+    refute_equal pooled_norm.first.to_a, cls.first.to_a
+  end
+
+  def test_embedding_default_is_pooled
+    pooled = @model.embedding(@string, "pooled")
+    default = @model.embedding(@string)
+    assert_equal pooled.first.to_a, default.first.to_a
+  end
+end

--- a/test/model_pooling_test.rb
+++ b/test/model_pooling_test.rb
@@ -19,7 +19,7 @@ class ModelPoolingTest < Minitest::Test
     # Manually pool and then normalize
     pooled_manual = @embeddings.mean(1)
     norm = pooled_manual / Math.sqrt(pooled_manual.sqr.sum(1).values.first)
-    assert_in_delta pooled_norm_ruby.first.to_a[0], norm.first.to_a[0], 1e-3
+    assert_in_delta pooled_norm_ruby.first.to_a[0], norm.first.to_a[0], 1e-5
   end
 
   def test_pool_cls_embedding

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -1,0 +1,20 @@
+require_relative "test_helper"
+
+class ModelTest < Minitest::Test
+  def test_pooled_embeddings_shape
+    model = Candle::Model.new
+    string = "Hi there"
+    embeddings = model.embeddings(string)
+    pooled = model.pool_and_normalize_embedding(embeddings)
+    assert_equal pooled.shape, [1, 768]
+  end
+
+  def test_pooled_embeddings
+    model = Candle::Model.new
+    string = "Hi there"
+    embeddings = model.embeddings(string)
+    pooled = model.pool_and_normalize_embedding(embeddings)
+    embedding = model.embedding(string)
+    assert_equal pooled.first.to_a, embedding.first.to_a
+  end
+end

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -13,7 +13,7 @@ class ModelTest < Minitest::Test
     model = Candle::Model.new
     string = "Hi there"
     embeddings = model.embeddings(string)
-    pooled = model.pool_and_normalize_embedding(embeddings)
+    pooled = model.pool_embedding(embeddings)
     embedding = model.embedding(string)
     assert_equal pooled.first.to_a, embedding.first.to_a
   end

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -23,11 +23,6 @@ class ModelTypesTest < Minitest::Test
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_safetensor_initialize_jina_bert
-    model_type = Candle::ModelType::JINA_BERT
-    model_option = { model_path: "jinaai/jina-embeddings-v2-base-en", embedding_size: 768 }
-    initialize_model_for_type(model_type, model_option)
-  end
 
   def test_initialize_standard_bert
     model_type = Candle::ModelType::STANDARD_BERT
@@ -35,11 +30,6 @@ class ModelTypesTest < Minitest::Test
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_safetensor_initialize_standard_bert
-    model_type = Candle::ModelType::STANDARD_BERT
-    model_option = { model_path: "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext", embedding_size: 768 }
-    initialize_model_for_type(model_type, model_option)
-  end
 
   def test_initialize_minilm
     model_type = Candle::ModelType::MINILM
@@ -47,11 +37,6 @@ class ModelTypesTest < Minitest::Test
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_safetensor_initialize_minilm
-    model_type = Candle::ModelType::MINILM
-    model_option = { model_path: "sentence-transformers/all-MiniLM-L6-v2", embedding_size: 384 }
-    initialize_model_for_type(model_type, model_option)
-  end
 
   def test_initialize_distilbert
     model_type = Candle::ModelType::DISTILBERT
@@ -59,9 +44,4 @@ class ModelTypesTest < Minitest::Test
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_safetensor_initialize_distilbert
-    model_type = Candle::ModelType::DISTILBERT
-    model_option = { model_path: "scientistcom/distilbert-base-uncased-finetuned-sst-2-english", embedding_size: 768 }
-    initialize_model_for_type(model_type, model_option)
-  end
 end

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -17,10 +17,6 @@ class ModelTypesTest < Minitest::Test
     Candle::ModelType::DISTILBERT => [{
       model_path: "scientistcom/distilbert-base-uncased-finetuned-sst-2-english",
       embedding_size: 768
-    }],
-    Candle::ModelType::LLAMA => [{
-      model_path: "meta-llama/Llama-2-7b",
-      embedding_size: 4096
     }]
     # Add more safetensors models as needed
   }
@@ -33,18 +29,7 @@ class ModelTypesTest < Minitest::Test
         embedding_size = model_option[:embedding_size]
         puts ">>>>>>>>>>>>> model_path #{model_path} model_type #{model_type}"
 
-        if model_type == Candle::ModelType::LLAMA
-          # Llama: should succeed if GGML is present, fail with safetensors or bin
-          assert_raises RuntimeError, /safetensors|not yet implemented|not found/ do
-            Candle::Model.new(
-              model_path: model_path,
-              tokenizer_path: model_path,
-              model_type: model_type,
-              device: nil,
-              embedding_size: embedding_size
-            )
-          end
-        elsif model_type == Candle::ModelType::STANDARD_BERT
+        if model_type == Candle::ModelType::STANDARD_BERT
           # These official models do not provide safetensors, should error helpfully
           assert_raises RuntimeError, /model\.safetensors not found|Only safetensors models are supported/ do
             Candle::Model.new(
@@ -92,37 +77,6 @@ class ModelTypesTest < Minitest::Test
           raise e
         end
       end
-    end
-  end
-
-  def test_llama_ggml_and_pytorch_bin
-    llama_model = "meta-llama/Llama-2-7b"
-    # Should error for safetensors (not implemented)
-    assert_raises RuntimeError, /Llama safetensors loading is not yet implemented/ do
-      Candle::Model.new(
-        model_path: llama_model,
-        tokenizer_path: llama_model,
-        model_type: Candle::ModelType::LLAMA,
-        device: nil
-      )
-    end
-    # Should error for missing ggml
-    assert_raises RuntimeError, /model\.ggml not found/ do
-      Candle::Model.new(
-        model_path: "some/llama-without-ggml",
-        tokenizer_path: "some/llama-without-ggml",
-        model_type: Candle::ModelType::LLAMA,
-        device: nil
-      )
-    end
-    # Should error for pytorch_model.bin
-    assert_raises RuntimeError, /model\.safetensors not found|Only safetensors models are supported/ do
-      Candle::Model.new(
-        model_path: "bert-base-uncased", # This repo only provides pytorch_model.bin
-        tokenizer_path: "bert-base-uncased",
-        model_type: Candle::ModelType::STANDARD_BERT,
-        device: nil
-      )
     end
   end
 end

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -1,26 +1,6 @@
 require_relative "test_helper"
 
 class ModelTypesTest < Minitest::Test
-  SAFETENSOR_MODELS = {
-    Candle::ModelType::JINA_BERT => [{
-      model_path: "jinaai/jina-embeddings-v2-base-en",
-      embedding_size: 768
-    }],
-    Candle::ModelType::STANDARD_BERT => [{
-      model_path: "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext",
-      embedding_size: 768
-    }],
-    Candle::ModelType::MINILM => [{
-      model_path: "sentence-transformers/all-MiniLM-L6-v2",
-      embedding_size: 384
-    }],
-    Candle::ModelType::DISTILBERT => [{
-      model_path: "scientistcom/distilbert-base-uncased-finetuned-sst-2-english",
-      embedding_size: 768
-    }]
-    # Add more safetensors models as needed
-  }
-
   # Helper to initialize a model and assert correctness
   private def initialize_model_for_type(model_type, model_option)
     model_path = model_option[:model_path]

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -21,62 +21,69 @@ class ModelTypesTest < Minitest::Test
     # Add more safetensors models as needed
   }
 
-  def test_model_types_initialize
-    # Test all model types with their default Hugging Face repos
-    SAFETENSOR_MODELS.each do |model_type, model_options|
-      model_options.each do |model_option|
-        model_path = model_option[:model_path]
-        embedding_size = model_option[:embedding_size]
-        puts ">>>>>>>>>>>>> model_path #{model_path} model_type #{model_type}"
-
-        if model_type == Candle::ModelType::STANDARD_BERT
-          # These official models do not provide safetensors, should error helpfully
-          assert_raises RuntimeError, /model\.safetensors not found|Only safetensors models are supported/ do
-            Candle::Model.new(
-              model_path: model_path,
-              tokenizer_path: model_path,
-              model_type: model_type,
-              device: nil,
-              embedding_size: embedding_size
-            )
-          end
-        else
-          # Should succeed for models with safetensors
-          model = Candle::Model.new(
-            model_path: model_path,
-            tokenizer_path: model_path,
-            model_type: model_type,
-            device: nil,
-            embedding_size: embedding_size
-          )
-          assert model, "Model should be initialized for #{model_type}"
-        end
-      end
-    end
+  # Helper to initialize a model and assert correctness
+  private def initialize_model_for_type(model_type, model_option)
+    model_path = model_option[:model_path]
+    embedding_size = model_option[:embedding_size]
+    model = Candle::Model.new(
+      model_path: model_path,
+      tokenizer_path: model_path,
+      model_type: model_type,
+      device: nil,
+      embedding_size: embedding_size
+    )
+    assert model, "Model should be initialized for #{model_type}"
   end
 
-  def test_safetensor_model_types_initialize
-    SAFETENSOR_MODELS.each do |model_type, model_options|
-      model_options.each do |model_option|
-        model_path = model_option[:model_path]
-        embedding_size = model_option[:embedding_size]
-        begin
-          model = Candle::Model.new(
-            model_path: model_path,
-            tokenizer_path: model_path,
-            model_type: model_type,
-            device: nil,
-            embedding_size: embedding_size
-          )
-          assert model, "Model should be initialized for #{model_type}"
-        rescue => e
-          puts e.message
-          puts e.backtrace.join("\n")
-          puts "Initializing model for [#{model_type}]"
-          puts model_option.inspect
-          raise e
-        end
-      end
-    end
+  # Individual tests for each model type (explicitly written)
+
+  def test_initialize_jina_bert_0
+    model_type = Candle::ModelType::JINA_BERT
+    model_option = { model_path: "jinaai/jina-embeddings-v2-base-en", embedding_size: 768 }
+    initialize_model_for_type(model_type, model_option)
   end
+
+  def test_safetensor_initialize_jina_bert_0
+    model_type = Candle::ModelType::JINA_BERT
+    model_option = { model_path: "jinaai/jina-embeddings-v2-base-en", embedding_size: 768 }
+    initialize_model_for_type(model_type, model_option)
+  end
+
+  def test_initialize_standard_bert_0
+    model_type = Candle::ModelType::STANDARD_BERT
+    model_option = { model_path: "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext", embedding_size: 768 }
+    initialize_model_for_type(model_type, model_option)
+  end
+
+  def test_safetensor_initialize_standard_bert_0
+    model_type = Candle::ModelType::STANDARD_BERT
+    model_option = { model_path: "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext", embedding_size: 768 }
+    initialize_model_for_type(model_type, model_option)
+  end
+
+  def test_initialize_minilm_0
+    model_type = Candle::ModelType::MINILM
+    model_option = { model_path: "sentence-transformers/all-MiniLM-L6-v2", embedding_size: 384 }
+    initialize_model_for_type(model_type, model_option)
+  end
+
+  def test_safetensor_initialize_minilm_0
+    model_type = Candle::ModelType::MINILM
+    model_option = { model_path: "sentence-transformers/all-MiniLM-L6-v2", embedding_size: 384 }
+    initialize_model_for_type(model_type, model_option)
+  end
+
+  def test_initialize_distilbert_0
+    model_type = Candle::ModelType::DISTILBERT
+    model_option = { model_path: "scientistcom/distilbert-base-uncased-finetuned-sst-2-english", embedding_size: 768 }
+    initialize_model_for_type(model_type, model_option)
+  end
+
+  def test_safetensor_initialize_distilbert_0
+    model_type = Candle::ModelType::DISTILBERT
+    model_option = { model_path: "scientistcom/distilbert-base-uncased-finetuned-sst-2-english", embedding_size: 768 }
+    initialize_model_for_type(model_type, model_option)
+  end
+
+
 end

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -1,0 +1,64 @@
+require_relative "test_helper"
+
+class ModelTypesTest < Minitest::Test
+  MODEL_TYPES = {
+    Candle::ModelType::JINA_BERT => "jinaai/jina-embeddings-v2-base-en",
+    Candle::ModelType::STANDARD_BERT => "bert-base-uncased",
+    Candle::ModelType::MINILM => "sentence-transformers/all-MiniLM-L6-v2",
+    Candle::ModelType::SENTIMENT => "distilbert-base-uncased-finetuned-sst-2-english",
+    Candle::ModelType::LLAMA => "meta-llama/Llama-2-7b"
+  }
+
+  SAFETENSOR_MODELS = {
+    Candle::ModelType::JINA_BERT => {
+      model_path: "jinaai/jina-embeddings-v2-base-en",
+      embedding_size: 768
+    },
+    Candle::ModelType::STANDARD_BERT => {
+      model_path: "bert-base-uncased",
+      embedding_size: 768
+    },
+    Candle::ModelType::MINILM => {
+      model_path: "sentence-transformers/all-MiniLM-L6-v2",
+      embedding_size: 384
+    },
+    # Add more safetensors models as needed
+  }
+
+  def test_model_types_initialize
+    MODEL_TYPES.each do |model_type, model_path|
+      # Llama may require a token, so we skip it by default
+      next if model_type == Candle::ModelType::LLAMA
+
+      embedding_size = case model_type
+        when Candle::ModelType::JINA_BERT then 768
+        when Candle::ModelType::STANDARD_BERT then 768
+        when Candle::ModelType::MINILM then 384
+        when Candle::ModelType::SENTIMENT then 768
+        else nil
+      end
+
+      model = Candle::Model.new(
+        model_path: model_path,
+        tokenizer_path: model_path,
+        model_type: model_type,
+        device: nil,
+        embedding_size: embedding_size
+      )
+      assert model, "Model should be initialized for #{model_type}"
+    end
+  end
+
+  def test_safetensor_model_types_initialize
+    SAFETENSOR_MODELS.each do |model_type, info|
+      model = Candle::Model.new(
+        model_path: info[:model_path],
+        tokenizer_path: info[:model_path],
+        model_type: model_type,
+        device: nil,
+        embedding_size: info[:embedding_size]
+      )
+      assert model, "Model should be initialized for #{model_type}"
+    end
+  end
+end

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -26,26 +26,50 @@ class ModelTypesTest < Minitest::Test
   }
 
   def test_model_types_initialize
+    # Test all model types with their default Hugging Face repos
     MODEL_TYPES.each do |model_type, model_path|
-      # Llama may require a token, so we skip it by default
-      next if model_type == Candle::ModelType::LLAMA
-
       embedding_size = case model_type
         when Candle::ModelType::JINA_BERT then 768
         when Candle::ModelType::STANDARD_BERT then 768
         when Candle::ModelType::MINILM then 384
         when Candle::ModelType::SENTIMENT then 768
+        when Candle::ModelType::LLAMA then nil
         else nil
       end
 
-      model = Candle::Model.new(
-        model_path: model_path,
-        tokenizer_path: model_path,
-        model_type: model_type,
-        device: nil,
-        embedding_size: embedding_size
-      )
-      assert model, "Model should be initialized for #{model_type}"
+      if model_type == Candle::ModelType::LLAMA
+        # Llama: should succeed if GGML is present, fail with safetensors or bin
+        assert_raises RuntimeError, /safetensors|not yet implemented|not found/ do
+          Candle::Model.new(
+            model_path: model_path,
+            tokenizer_path: model_path,
+            model_type: model_type,
+            device: nil,
+            embedding_size: embedding_size
+          )
+        end
+      elsif model_type == Candle::ModelType::STANDARD_BERT || model_type == Candle::ModelType::SENTIMENT
+        # These official models do not provide safetensors, should error helpfully
+        assert_raises RuntimeError, /model\.safetensors not found|Only safetensors models are supported/ do
+          Candle::Model.new(
+            model_path: model_path,
+            tokenizer_path: model_path,
+            model_type: model_type,
+            device: nil,
+            embedding_size: embedding_size
+          )
+        end
+      else
+        # Should succeed for models with safetensors
+        model = Candle::Model.new(
+          model_path: model_path,
+          tokenizer_path: model_path,
+          model_type: model_type,
+          device: nil,
+          embedding_size: embedding_size
+        )
+        assert model, "Model should be initialized for #{model_type}"
+      end
     end
   end
 
@@ -59,6 +83,37 @@ class ModelTypesTest < Minitest::Test
         embedding_size: info[:embedding_size]
       )
       assert model, "Model should be initialized for #{model_type}"
+    end
+  end
+
+  def test_llama_ggml_and_pytorch_bin
+    llama_model = "meta-llama/Llama-2-7b"
+    # Should error for safetensors (not implemented)
+    assert_raises RuntimeError, /Llama safetensors loading is not yet implemented/ do
+      Candle::Model.new(
+        model_path: llama_model,
+        tokenizer_path: llama_model,
+        model_type: Candle::ModelType::LLAMA,
+        device: nil
+      )
+    end
+    # Should error for missing ggml
+    assert_raises RuntimeError, /model\.ggml not found/ do
+      Candle::Model.new(
+        model_path: "some/llama-without-ggml",
+        tokenizer_path: "some/llama-without-ggml",
+        model_type: Candle::ModelType::LLAMA,
+        device: nil
+      )
+    end
+    # Should error for pytorch_model.bin
+    assert_raises RuntimeError, /model\.safetensors not found|Only safetensors models are supported/ do
+      Candle::Model.new(
+        model_path: "bert-base-uncased", # This repo only provides pytorch_model.bin
+        tokenizer_path: "bert-base-uncased",
+        model_type: Candle::ModelType::STANDARD_BERT,
+        device: nil
+      )
     end
   end
 end

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -17,53 +17,51 @@ class ModelTypesTest < Minitest::Test
 
   # Individual tests for each model type (explicitly written)
 
-  def test_initialize_jina_bert_0
+  def test_initialize_jina_bert
     model_type = Candle::ModelType::JINA_BERT
     model_option = { model_path: "jinaai/jina-embeddings-v2-base-en", embedding_size: 768 }
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_safetensor_initialize_jina_bert_0
+  def test_safetensor_initialize_jina_bert
     model_type = Candle::ModelType::JINA_BERT
     model_option = { model_path: "jinaai/jina-embeddings-v2-base-en", embedding_size: 768 }
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_initialize_standard_bert_0
+  def test_initialize_standard_bert
     model_type = Candle::ModelType::STANDARD_BERT
     model_option = { model_path: "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext", embedding_size: 768 }
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_safetensor_initialize_standard_bert_0
+  def test_safetensor_initialize_standard_bert
     model_type = Candle::ModelType::STANDARD_BERT
     model_option = { model_path: "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext", embedding_size: 768 }
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_initialize_minilm_0
+  def test_initialize_minilm
     model_type = Candle::ModelType::MINILM
     model_option = { model_path: "sentence-transformers/all-MiniLM-L6-v2", embedding_size: 384 }
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_safetensor_initialize_minilm_0
+  def test_safetensor_initialize_minilm
     model_type = Candle::ModelType::MINILM
     model_option = { model_path: "sentence-transformers/all-MiniLM-L6-v2", embedding_size: 384 }
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_initialize_distilbert_0
+  def test_initialize_distilbert
     model_type = Candle::ModelType::DISTILBERT
     model_option = { model_path: "scientistcom/distilbert-base-uncased-finetuned-sst-2-english", embedding_size: 768 }
     initialize_model_for_type(model_type, model_option)
   end
 
-  def test_safetensor_initialize_distilbert_0
+  def test_safetensor_initialize_distilbert
     model_type = Candle::ModelType::DISTILBERT
     model_option = { model_path: "scientistcom/distilbert-base-uncased-finetuned-sst-2-english", embedding_size: 768 }
     initialize_model_for_type(model_type, model_option)
   end
-
-
 end

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -3,7 +3,7 @@ require_relative "test_helper"
 class ModelTypesTest < Minitest::Test
   MODEL_TYPES = {
     Candle::ModelType::JINA_BERT => "jinaai/jina-embeddings-v2-base-en",
-    Candle::ModelType::STANDARD_BERT => "bert-base-uncased",
+    Candle::ModelType::STANDARD_BERT => "google-bert/bert-base-uncased",
     Candle::ModelType::MINILM => "sentence-transformers/all-MiniLM-L6-v2",
     Candle::ModelType::SENTIMENT => "distilbert-base-uncased-finetuned-sst-2-english",
     Candle::ModelType::LLAMA => "meta-llama/Llama-2-7b"
@@ -15,7 +15,7 @@ class ModelTypesTest < Minitest::Test
       embedding_size: 768
     },
     Candle::ModelType::STANDARD_BERT => {
-      model_path: "bert-base-uncased",
+      model_path: "google-bert/bert-base-uncased",
       embedding_size: 768
     },
     Candle::ModelType::MINILM => {
@@ -75,14 +75,22 @@ class ModelTypesTest < Minitest::Test
 
   def test_safetensor_model_types_initialize
     SAFETENSOR_MODELS.each do |model_type, info|
-      model = Candle::Model.new(
-        model_path: info[:model_path],
-        tokenizer_path: info[:model_path],
-        model_type: model_type,
-        device: nil,
-        embedding_size: info[:embedding_size]
-      )
-      assert model, "Model should be initialized for #{model_type}"
+      begin
+        model = Candle::Model.new(
+          model_path: info[:model_path],
+          tokenizer_path: info[:model_path],
+          model_type: model_type,
+          device: nil,
+          embedding_size: info[:embedding_size]
+        )
+        assert model, "Model should be initialized for #{model_type}"
+      rescue => e
+        puts e.message
+        puts e.backtrace.join("\n")
+        puts "Initializing model for [#{model_type}]"
+        puts info.inspect
+        raise e
+      end
     end
   end
 

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -9,13 +9,14 @@ class ModelTypesTest < Minitest::Test
     Candle::ModelType::STANDARD_BERT => [{
       model_path: "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext",
       embedding_size: 768
-    }, {
-      model_path: "scientistcom/distilbert-base-uncased-finetuned-sst-2-english",
-      embedding_size: 768
     }],
     Candle::ModelType::MINILM => [{
       model_path: "sentence-transformers/all-MiniLM-L6-v2",
       embedding_size: 384
+    }],
+    Candle::ModelType::DISTILBERT => [{
+      model_path: "scientistcom/distilbert-base-uncased-finetuned-sst-2-english",
+      embedding_size: 768
     }],
     Candle::ModelType::LLAMA => [{
       model_path: "meta-llama/Llama-2-7b",


### PR DESCRIPTION
Allow for other embedding model types, including:
 * Jina (already supported)
  * MiniLm
  * BERT
  * DistilBERT

To test run:

```sh
./bin/setup
rake test
```

You can also do:
```sh
./bin/console
> model = Candle::Model.new
> em = model.embeddings("orange you glad I didn't say banana?")
> puts em
> puts pooled = model.pool_embedding(em)
> puts model.pool_and_normalize_embedding(em)
> puts model.pool_cls_embedding(em)

> model = Candle::Model.new(
  model_path: "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext",
  tokenizer_path: "scientistcom/BiomedNLP-BiomedBERT-base-uncased-abstract-fulltext",
  model_type: Candle::ModelType::STANDARD_BERT,
  device: nil,
  embedding_size: 768
)
> em = model.embeddings("orange you glad I didn't say banana?")
> puts em
> puts pooled = model.pool_embedding(em)
> puts model.pool_and_normalize_embedding(em)
> puts model.pool_cls_embedding(em)
```