### PR TITLE
Fix reranker method comment

### DIFF
--- a/lib/candle/reranker.rb
+++ b/lib/candle/reranker.rb
@@ -10,7 +10,7 @@ module Candle
       _create(model_path, device)
     end
 
-    # Returns the embedding for a string using the specified pooling method.
+    # Returns documents ranked by relevance using the specified pooling method.
     # @param query [String] The input text
     # @param documents [Array<String>] The list of documents to compare against
     # @param pooling_method [String] Pooling method: "pooler", "cls", or "mean". Default: "pooler"


### PR DESCRIPTION
## Summary
- fix comment in `Candle::Reranker` to accurately describe return value

## Testing
- `bundle exec rake test` *(fails: Connection Failed: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6877c8b7d5548328bfea81707fe1cf76