### PR TITLE
Phi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This guide captures the coding conventions and patterns used in the red-candle R
 
 ## Project Overview
 
-Red Candle is a Ruby gem that uses the Magnus Rust crate to embed Rust code in Ruby, providing access to the Candle ML library from Hugging Face. It enables Ruby developers to use embedding models, rerankers, and LLMs including Llama, Mistral, Gemma, and Qwen models.
+Red Candle is a Ruby gem that uses the Magnus Rust crate to embed Rust code in Ruby, providing access to the Candle ML library from Hugging Face. It enables Ruby developers to use embedding models, rerankers, and LLMs including Llama, Mistral, Gemma, Qwen, and Phi models.
 
 ## Architecture Overview
 
@@ -190,7 +190,7 @@ red-candle/
 - Single module namespace: `Candle`
 - Clear class responsibilities:
   - `Tensor` - Core tensor operations
-  - `LLM` - Language model functionality
+  - `LLM` - Language model functionality (Llama, Mistral, Gemma, Qwen, Phi)
   - `EmbeddingModel` - Text embeddings
   - `Reranker` - Document reranking
   - `Tokenizer` - Text tokenization

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Red-Candle now supports Large Language Models (LLMs) with GPU acceleration!
 - **Gemma**: Google's Gemma models (e.g., `google/gemma-2b`, `google/gemma-7b`, `google/gemma-2b-it`)
 - **Llama**: Llama 2 and Llama 3 models (e.g., `TinyLlama/TinyLlama-1.1B-Chat-v1.0`, `meta-llama/Llama-2-7b-hf`, `NousResearch/Llama-2-7b-hf`)
 - **Mistral**: All Mistral models (e.g., `mistralai/Mistral-7B-Instruct-v0.1`)
+- **Qwen**: Qwen 2 and 2.5 models (e.g., `Qwen/Qwen2-1.5B`, `Qwen/Qwen2.5-7B-Instruct`)
+- **Phi**: Microsoft's Phi-2 and Phi-3 models (e.g., `microsoft/phi-2`, `microsoft/Phi-3-mini-4k-instruct`)
 
 ### Quantized Model Support (GGUF)
 

--- a/examples/phi_example.rb
+++ b/examples/phi_example.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+
+require 'candle'
+
+device = Candle::Device.cpu
+
+puts "Phi Model Examples"
+puts "=================="
+puts ""
+puts "Note: The first run will download model files, which may take a few minutes."
+puts ""
+
+# Example 1: Using a GGUF Phi model (if available)
+puts "1. Loading a Phi GGUF model (smaller, faster):"
+puts "   You can use models like:"
+puts "   - TheBloke/phi-2-GGUF with gguf_file: 'phi-2.Q4_K_M.gguf'"
+puts "   - Look for Phi-3 GGUF models on HuggingFace"
+puts ""
+
+# Example 2: Phi-2 basic usage
+puts "2. Basic Phi-2 generation:"
+puts <<-RUBY
+llm = Candle::LLM.from_pretrained("microsoft/phi-2", device: device)
+prompt = "Write a Python function to calculate the factorial of a number:"
+result = llm.generate(prompt, config: Candle::GenerationConfig.new(max_length: 100))
+puts result
+RUBY
+
+# Example 3: Phi-3 chat
+puts "\n3. Phi-3 chat interface:"
+puts <<-RUBY
+llm = Candle::LLM.from_pretrained("microsoft/Phi-3-mini-4k-instruct", device: device)
+messages = [
+  { role: "system", content: "You are a helpful coding assistant." },
+  { role: "user", content: "How do I reverse a string in Ruby?" }
+]
+response = llm.chat(messages, config: Candle::GenerationConfig.balanced)
+puts response
+RUBY
+
+# Example 4: Streaming
+puts "\n4. Streaming generation:"
+puts <<-RUBY
+llm.generate_stream("The key principles of object-oriented programming are") do |token|
+  print token
+end
+RUBY
+
+puts "\n\nNote: microsoft/phi-2 uses sharded weights (multiple files), so the initial download"
+puts "may take longer than single-file models. The model files are cached after first download."

--- a/ext/candle/src/llm/mod.rs
+++ b/ext/candle/src/llm/mod.rs
@@ -4,6 +4,7 @@ pub mod mistral;
 pub mod llama;
 pub mod gemma;
 pub mod qwen;
+pub mod phi;
 pub mod generation_config;
 pub mod text_generation;
 pub mod quantized_gguf;

--- a/ext/candle/src/llm/phi.rs
+++ b/ext/candle/src/llm/phi.rs
@@ -1,0 +1,261 @@
+use candle_core::{DType, Device, Result as CandleResult, Tensor};
+use candle_transformers::models::phi::{Config, Model as PhiModel};
+use candle_transformers::models::phi3::{Config as Phi3Config, Model as Phi3Model};
+use hf_hub::api::tokio::Api;
+use tokenizers::Tokenizer;
+
+use crate::llm::{GenerationConfig, TextGeneration, TextGenerator, TokenizerWrapper};
+
+/// Phi model wrapper for text generation
+pub struct Phi {
+    model: PhiVariant,
+    tokenizer: TokenizerWrapper,
+    device: Device,
+    model_id: String,
+    eos_token_id: u32,
+}
+
+enum PhiVariant {
+    Phi2(PhiModel),
+    Phi3(Phi3Model),
+}
+
+impl Phi {
+    /// Get the tokenizer
+    pub fn tokenizer(&self) -> &TokenizerWrapper {
+        &self.tokenizer
+    }
+    
+    /// Clear the KV cache between generations
+    pub fn clear_kv_cache(&mut self) {
+        match &mut self.model {
+            PhiVariant::Phi2(model) => model.clear_kv_cache(),
+            PhiVariant::Phi3(model) => model.clear_kv_cache(),
+        }
+    }
+    
+    /// Load a Phi model from HuggingFace
+    pub async fn from_pretrained(model_id: &str, device: Device) -> CandleResult<Self> {
+        let api = Api::new()
+            .map_err(|e| candle_core::Error::Msg(format!("Failed to create HF API: {}", e)))?;
+        
+        let repo = api.model(model_id.to_string());
+        
+        // Download configuration
+        let config_filename = repo.get("config.json").await
+            .map_err(|e| candle_core::Error::Msg(format!("Failed to download config: {}", e)))?;
+        let config_str = std::fs::read_to_string(config_filename)?;
+        
+        // Download tokenizer
+        let tokenizer_filename = repo.get("tokenizer.json").await
+            .map_err(|e| candle_core::Error::Msg(format!("Failed to download tokenizer: {}", e)))?;
+        let tokenizer = Tokenizer::from_file(tokenizer_filename)
+            .map_err(|e| candle_core::Error::Msg(format!("Failed to load tokenizer: {}", e)))?;
+        
+        // Determine EOS token
+        let vocab = tokenizer.get_vocab(true);
+        let eos_token_id = vocab.get("<|endoftext|>")
+            .or_else(|| vocab.get("<|end|>"))
+            .or_else(|| vocab.get("</s>"))
+            .copied()
+            .unwrap_or(50256); // Default GPT-2 style EOS token
+        
+        // Determine model variant based on model_id or config
+        let is_phi3 = model_id.contains("phi-3") || model_id.contains("Phi-3");
+        
+        let model = if is_phi3 {
+            // Load Phi3 model
+            let config: Phi3Config = serde_json::from_str(&config_str)
+                .map_err(|e| candle_core::Error::Msg(format!("Failed to parse Phi3 config: {}", e)))?;
+            
+            // Download model weights
+            let model_filename = repo.get("model.safetensors").await
+                .map_err(|e| candle_core::Error::Msg(format!("Failed to download model weights: {}", e)))?;
+            
+            let vb = unsafe {
+                candle_nn::VarBuilder::from_mmaped_safetensors(&[model_filename], DType::F32, &device)?
+            };
+            
+            let model = Phi3Model::new(&config, vb)?;
+            PhiVariant::Phi3(model)
+        } else {
+            // Load Phi2 model
+            let config: Config = serde_json::from_str(&config_str)
+                .map_err(|e| candle_core::Error::Msg(format!("Failed to parse Phi config: {}", e)))?;
+            
+            // Download model weights
+            let model_filename = repo.get("model.safetensors").await
+                .map_err(|e| candle_core::Error::Msg(format!("Failed to download model weights: {}", e)))?;
+            
+            let vb = unsafe {
+                candle_nn::VarBuilder::from_mmaped_safetensors(&[model_filename], DType::F32, &device)?
+            };
+            
+            let model = PhiModel::new(&config, vb)?;
+            PhiVariant::Phi2(model)
+        };
+        
+        Ok(Self {
+            model,
+            tokenizer: TokenizerWrapper::new(tokenizer),
+            device,
+            model_id: model_id.to_string(),
+            eos_token_id,
+        })
+    }
+    
+    /// Apply Phi chat template to messages
+    pub fn apply_chat_template(&self, messages: &[serde_json::Value]) -> CandleResult<String> {
+        let mut prompt = String::new();
+        
+        // Phi-3 uses a specific format
+        if matches!(self.model, PhiVariant::Phi3(_)) {
+            for message in messages {
+                let role = message["role"].as_str().unwrap_or("");
+                let content = message["content"].as_str().unwrap_or("");
+                
+                match role {
+                    "system" => {
+                        prompt.push_str(&format!("<|system|>\n{}<|end|>\n", content));
+                    }
+                    "user" => {
+                        prompt.push_str(&format!("<|user|>\n{}<|end|>\n", content));
+                    }
+                    "assistant" => {
+                        prompt.push_str(&format!("<|assistant|>\n{}<|end|>\n", content));
+                    }
+                    _ => {}
+                }
+            }
+            prompt.push_str("<|assistant|>\n");
+        } else {
+            // Phi-2 uses a simpler format
+            for message in messages {
+                let role = message["role"].as_str().unwrap_or("");
+                let content = message["content"].as_str().unwrap_or("");
+                
+                match role {
+                    "system" => prompt.push_str(&format!("System: {}\n", content)),
+                    "user" => prompt.push_str(&format!("User: {}\n", content)),
+                    "assistant" => prompt.push_str(&format!("Assistant: {}\n", content)),
+                    _ => {}
+                }
+            }
+            prompt.push_str("Assistant: ");
+        }
+        
+        Ok(prompt)
+    }
+    
+    fn generate_tokens(
+        &mut self,
+        prompt_tokens: Vec<u32>,
+        config: &GenerationConfig,
+        mut callback: Option<impl FnMut(&str)>,
+    ) -> CandleResult<Vec<u32>> {
+        let mut text_gen = TextGeneration::from_config(config);
+        text_gen.set_eos_token_id(self.eos_token_id);
+        text_gen.set_tokens(prompt_tokens.clone());
+        
+        let mut all_tokens = prompt_tokens.clone();
+        let start_gen = all_tokens.len();
+        
+        for index in 0..config.max_length {
+            let context_size = if index > 0 { 1 } else { all_tokens.len() };
+            let start_pos = all_tokens.len().saturating_sub(context_size);
+            let ctxt = &all_tokens[start_pos..];
+            
+            let input = Tensor::new(ctxt, &self.device)?.unsqueeze(0)?;
+            let logits = match &mut self.model {
+                PhiVariant::Phi2(model) => model.forward(&input)?,
+                PhiVariant::Phi3(model) => model.forward(&input, start_pos)?,
+            };
+            let logits = logits.squeeze(0)?;
+            
+            // Handle different output shapes
+            let logits = if logits.dims().len() == 2 {
+                let seq_len = logits.dim(0)?;
+                logits.narrow(0, seq_len - 1, 1)?.squeeze(0)?
+            } else {
+                logits
+            };
+            
+            let logits = logits.to_dtype(DType::F32)?;
+            
+            let next_token = text_gen.sample_next_token(
+                &logits,
+                Some((config.repetition_penalty, config.repetition_penalty_last_n)),
+            )?;
+            
+            all_tokens.push(next_token);
+            
+            // Stream callback
+            if let Some(ref mut cb) = callback {
+                if config.debug_tokens {
+                    let token_piece = self.tokenizer.token_to_piece(next_token)?;
+                    cb(&format!("[{}:{}]", next_token, token_piece));
+                } else {
+                    let decoded_text = self.tokenizer.decode_incremental(&all_tokens, all_tokens.len() - 1)?;
+                    cb(&decoded_text);
+                }
+            }
+            
+            // Check stop conditions
+            if text_gen.should_stop(next_token, config.max_length) {
+                break;
+            }
+            
+            // Check stop sequences
+            let generated_text = self.tokenizer.decode(&all_tokens[start_gen..], true)?;
+            if text_gen.check_stop_sequences(&generated_text, &config.stop_sequences) {
+                break;
+            }
+        }
+        
+        Ok(if config.include_prompt {
+            all_tokens
+        } else {
+            all_tokens[start_gen..].to_vec()
+        })
+    }
+}
+
+impl TextGenerator for Phi {
+    fn generate(
+        &mut self,
+        prompt: &str,
+        config: &GenerationConfig,
+    ) -> CandleResult<String> {
+        let prompt_tokens = self.tokenizer.encode(prompt, true)?;
+        let output_tokens = self.generate_tokens(prompt_tokens, config, None::<fn(&str)>)?;
+        
+        if config.debug_tokens {
+            self.tokenizer.format_tokens_with_debug(&output_tokens)
+        } else {
+            self.tokenizer.decode(&output_tokens, true)
+        }
+    }
+
+    fn generate_stream(
+        &mut self,
+        prompt: &str,
+        config: &GenerationConfig,
+        mut callback: impl FnMut(&str),
+    ) -> CandleResult<String> {
+        let prompt_tokens = self.tokenizer.encode(prompt, true)?;
+        let output_tokens = self.generate_tokens(prompt_tokens, config, Some(&mut callback))?;
+        self.tokenizer.decode(&output_tokens, true)
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model_id
+    }
+
+    fn device(&self) -> &Device {
+        &self.device
+    }
+    
+    fn clear_cache(&mut self) {
+        self.clear_kv_cache();
+    }
+}

--- a/ext/candle/src/llm/phi.rs
+++ b/ext/candle/src/llm/phi.rs
@@ -63,17 +63,45 @@ impl Phi {
         // Determine model variant based on model_id or config
         let is_phi3 = model_id.contains("phi-3") || model_id.contains("Phi-3");
         
+        // Download model weights (handle both single and sharded files)
+        let weights_filenames = if let Ok(single_file) = repo.get("model.safetensors").await {
+            vec![single_file]
+        } else {
+            // Try to find sharded model files
+            let mut sharded_files = Vec::new();
+            let mut index = 1;
+            loop {
+                // Try common shard counts
+                let mut found = false;
+                for total in [2, 3, 4, 5, 6, 7, 8, 10, 15, 20, 30] {
+                    let filename = format!("model-{:05}-of-{:05}.safetensors", index, total);
+                    if let Ok(file) = repo.get(&filename).await {
+                        sharded_files.push(file);
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    break;
+                }
+                index += 1;
+            }
+            
+            if sharded_files.is_empty() {
+                return Err(candle_core::Error::Msg(
+                    "Could not find model weights. Tried: model.safetensors, model-*-of-*.safetensors".to_string()
+                ));
+            }
+            sharded_files
+        };
+        
         let model = if is_phi3 {
             // Load Phi3 model
             let config: Phi3Config = serde_json::from_str(&config_str)
                 .map_err(|e| candle_core::Error::Msg(format!("Failed to parse Phi3 config: {}", e)))?;
             
-            // Download model weights
-            let model_filename = repo.get("model.safetensors").await
-                .map_err(|e| candle_core::Error::Msg(format!("Failed to download model weights: {}", e)))?;
-            
             let vb = unsafe {
-                candle_nn::VarBuilder::from_mmaped_safetensors(&[model_filename], DType::F32, &device)?
+                candle_nn::VarBuilder::from_mmaped_safetensors(&weights_filenames, DType::F32, &device)?
             };
             
             let model = Phi3Model::new(&config, vb)?;
@@ -83,12 +111,8 @@ impl Phi {
             let config: Config = serde_json::from_str(&config_str)
                 .map_err(|e| candle_core::Error::Msg(format!("Failed to parse Phi config: {}", e)))?;
             
-            // Download model weights
-            let model_filename = repo.get("model.safetensors").await
-                .map_err(|e| candle_core::Error::Msg(format!("Failed to download model weights: {}", e)))?;
-            
             let vb = unsafe {
-                candle_nn::VarBuilder::from_mmaped_safetensors(&[model_filename], DType::F32, &device)?
+                candle_nn::VarBuilder::from_mmaped_safetensors(&weights_filenames, DType::F32, &device)?
             };
             
             let model = PhiModel::new(&config, vb)?;

--- a/ext/candle/src/llm/quantized_gguf.rs
+++ b/ext/candle/src/llm/quantized_gguf.rs
@@ -144,7 +144,7 @@ impl QuantizedGGUF {
                     Err(e) => return Err(e),
                 }
             }
-            "phi" => {
+            "phi" | "phi2" => {
                 let model = QuantizedPhiModel::from_gguf(content, &mut file, &device)?;
                 ModelType::Phi(model)
             }
@@ -156,7 +156,7 @@ impl QuantizedGGUF {
             }
             _ => {
                 return Err(candle_core::Error::Msg(format!(
-                    "Unsupported architecture: {}. Supported: llama, mistral, gemma, qwen, qwen2, qwen3, phi, phi3",
+                    "Unsupported architecture: {}. Supported: llama, mistral, gemma, qwen, qwen2, qwen3, phi, phi2, phi3",
                     architecture
                 )));
             }
@@ -195,6 +195,8 @@ impl QuantizedGGUF {
             Ok("qwen".to_string())
         } else if model_lower.contains("phi-3") || model_lower.contains("phi3") {
             Ok("phi3".to_string())
+        } else if model_lower.contains("phi-2") || model_lower.contains("phi2") {
+            Ok("phi2".to_string())
         } else if model_lower.contains("phi") {
             Ok("phi".to_string())
         } else {
@@ -290,7 +292,7 @@ impl QuantizedGGUF {
                     .copied()
                     .unwrap_or(151643) // Default Qwen3 EOS token
             }
-            "phi" | "phi3" => {
+            "phi" | "phi2" | "phi3" => {
                 vocab.get("<|endoftext|>")
                     .or_else(|| vocab.get("<|end|>"))
                     .or_else(|| vocab.get("</s>"))
@@ -337,7 +339,7 @@ impl QuantizedGGUF {
                 "qwen" | "qwen2" | "qwen3" => {
                     self.apply_qwen_template(messages)
                 }
-                "phi" | "phi3" => {
+                "phi" | "phi2" | "phi3" => {
                     self.apply_phi_template(messages)
                 }
                 _ => Ok(self.apply_generic_template(messages))
@@ -467,7 +469,7 @@ impl QuantizedGGUF {
     fn apply_phi_template(&self, messages: &[serde_json::Value]) -> CandleResult<String> {
         let mut prompt = String::new();
         
-        // Check if it's Phi-3 (newer format) or Phi-2 (simpler format)
+        // Check if it's Phi-3 (newer format) or Phi-2/Phi (simpler format)
         let is_phi3 = self.model_id.contains("phi-3") || self.model_id.contains("Phi-3") || self.architecture == "phi3";
         
         if is_phi3 {

--- a/ext/candle/src/llm/quantized_gguf.rs
+++ b/ext/candle/src/llm/quantized_gguf.rs
@@ -3,6 +3,8 @@ use candle_core::quantized::gguf_file;
 use candle_transformers::models::quantized_llama::ModelWeights as QuantizedLlamaModel;
 use candle_transformers::models::quantized_gemma3::ModelWeights as QuantizedGemmaModel;
 use candle_transformers::models::quantized_qwen2::ModelWeights as QuantizedQwenModel;
+use candle_transformers::models::quantized_phi::ModelWeights as QuantizedPhiModel;
+use candle_transformers::models::quantized_phi3::ModelWeights as QuantizedPhi3Model;
 use hf_hub::api::tokio::{Api, ApiRepo};
 use tokenizers::Tokenizer;
 use std::io::Seek;
@@ -24,6 +26,8 @@ enum ModelType {
     Llama(QuantizedLlamaModel),
     Gemma(QuantizedGemmaModel),
     Qwen(QuantizedQwenModel),
+    Phi(QuantizedPhiModel),
+    Phi3(QuantizedPhi3Model),
     // Mistral uses Llama loader due to tensor naming compatibility
 }
 
@@ -140,9 +144,19 @@ impl QuantizedGGUF {
                     Err(e) => return Err(e),
                 }
             }
+            "phi" => {
+                let model = QuantizedPhiModel::from_gguf(content, &mut file, &device)?;
+                ModelType::Phi(model)
+            }
+            "phi3" => {
+                // QuantizedPhi3Model requires an additional `approx` parameter
+                let approx = true; // Use approximation for better performance
+                let model = QuantizedPhi3Model::from_gguf(approx, content, &mut file, &device)?;
+                ModelType::Phi3(model)
+            }
             _ => {
                 return Err(candle_core::Error::Msg(format!(
-                    "Unsupported architecture: {}. Supported: llama, mistral, gemma, qwen, qwen2, qwen3",
+                    "Unsupported architecture: {}. Supported: llama, mistral, gemma, qwen, qwen2, qwen3, phi, phi3",
                     architecture
                 )));
             }
@@ -179,6 +193,10 @@ impl QuantizedGGUF {
             Ok("gemma".to_string())
         } else if model_lower.contains("qwen") {
             Ok("qwen".to_string())
+        } else if model_lower.contains("phi-3") || model_lower.contains("phi3") {
+            Ok("phi3".to_string())
+        } else if model_lower.contains("phi") {
+            Ok("phi".to_string())
         } else {
             Err(candle_core::Error::Msg(
                 "Could not determine model architecture from metadata or name".to_string()
@@ -272,6 +290,13 @@ impl QuantizedGGUF {
                     .copied()
                     .unwrap_or(151643) // Default Qwen3 EOS token
             }
+            "phi" | "phi3" => {
+                vocab.get("<|endoftext|>")
+                    .or_else(|| vocab.get("<|end|>"))
+                    .or_else(|| vocab.get("</s>"))
+                    .copied()
+                    .unwrap_or(50256) // Default GPT-2 style EOS token
+            }
             _ => 2, // Default
         }
     }
@@ -295,6 +320,8 @@ impl QuantizedGGUF {
             self.apply_gemma_template(messages)
         } else if model_lower.contains("qwen") {
             self.apply_qwen_template(messages)
+        } else if model_lower.contains("phi") {
+            self.apply_phi_template(messages)
         } else {
             match self.architecture.as_str() {
                 "llama" => {
@@ -309,6 +336,9 @@ impl QuantizedGGUF {
                 }
                 "qwen" | "qwen2" | "qwen3" => {
                     self.apply_qwen_template(messages)
+                }
+                "phi" | "phi3" => {
+                    self.apply_phi_template(messages)
                 }
                 _ => Ok(self.apply_generic_template(messages))
             }
@@ -434,6 +464,51 @@ impl QuantizedGGUF {
         Ok(prompt)
     }
     
+    fn apply_phi_template(&self, messages: &[serde_json::Value]) -> CandleResult<String> {
+        let mut prompt = String::new();
+        
+        // Check if it's Phi-3 (newer format) or Phi-2 (simpler format)
+        let is_phi3 = self.model_id.contains("phi-3") || self.model_id.contains("Phi-3") || self.architecture == "phi3";
+        
+        if is_phi3 {
+            // Phi-3 format
+            for message in messages {
+                let role = message["role"].as_str().unwrap_or("");
+                let content = message["content"].as_str().unwrap_or("");
+                
+                match role {
+                    "system" => {
+                        prompt.push_str(&format!("<|system|>\n{}<|end|>\n", content));
+                    }
+                    "user" => {
+                        prompt.push_str(&format!("<|user|>\n{}<|end|>\n", content));
+                    }
+                    "assistant" => {
+                        prompt.push_str(&format!("<|assistant|>\n{}<|end|>\n", content));
+                    }
+                    _ => {}
+                }
+            }
+            prompt.push_str("<|assistant|>\n");
+        } else {
+            // Phi-2 format
+            for message in messages {
+                let role = message["role"].as_str().unwrap_or("");
+                let content = message["content"].as_str().unwrap_or("");
+                
+                match role {
+                    "system" => prompt.push_str(&format!("System: {}\n", content)),
+                    "user" => prompt.push_str(&format!("User: {}\n", content)),
+                    "assistant" => prompt.push_str(&format!("Assistant: {}\n", content)),
+                    _ => {}
+                }
+            }
+            prompt.push_str("Assistant: ");
+        }
+        
+        Ok(prompt)
+    }
+    
     fn apply_generic_template(&self, messages: &[serde_json::Value]) -> String {
         let mut prompt = String::new();
         
@@ -477,6 +552,8 @@ impl QuantizedGGUF {
                 ModelType::Llama(model) => model.forward(&input, start_pos)?,
                 ModelType::Gemma(model) => model.forward(&input, start_pos)?,
                 ModelType::Qwen(model) => model.forward(&input, start_pos)?,
+                ModelType::Phi(model) => model.forward(&input, start_pos)?,
+                ModelType::Phi3(model) => model.forward(&input, start_pos)?,
             };
             
             let logits = logits.squeeze(0)?;

--- a/lib/candle/llm.rb
+++ b/lib/candle/llm.rb
@@ -77,7 +77,16 @@ module Candle
         [/qwen.*?3.*?0\.5b/i, "Qwen/Qwen3-0.5B"],
         [/qwen.*?2\.5/i, "Qwen/Qwen2.5-0.5B"],
         [/qwen.*?2/i, "Qwen/Qwen2-1.5B"],
-        [/qwen/i, "Qwen/Qwen-1_8B"]
+        [/qwen/i, "Qwen/Qwen-1_8B"],
+        
+        # Phi models
+        [/phi.*?3.*?mini/i, "microsoft/Phi-3-mini-4k-instruct"],
+        [/phi.*?3.*?medium/i, "microsoft/Phi-3-medium-4k-instruct"],
+        [/phi.*?3.*?small/i, "microsoft/Phi-3-small-8k-instruct"],
+        [/phi.*?3/i, "microsoft/Phi-3-mini-4k-instruct"],
+        [/phi.*?2/i, "microsoft/phi-2"],
+        [/phi.*?1\.5/i, "microsoft/phi-1_5"],
+        [/phi/i, "microsoft/phi-2"]
       ]
     }
     

--- a/lib/candle/llm.rb
+++ b/lib/candle/llm.rb
@@ -46,6 +46,9 @@ module Candle
       "Qwen/Qwen3-32B-GGUF" => "Qwen/Qwen3-32B",
       "Qwen/Qwen3-72B-GGUF" => "Qwen/Qwen3-72B",
       
+      # Phi GGUF models
+      "TheBloke/phi-2-GGUF" => "microsoft/phi-2",
+      
       # Pattern-based fallbacks (evaluated in order)
       :patterns => [
         # Mistral models

--- a/test/llm/phi_test.rb
+++ b/test/llm/phi_test.rb
@@ -1,0 +1,61 @@
+require_relative "../test_helper"
+
+class PhiTest < Minitest::Test
+  def test_phi_tokenizer_registry
+    # Test exact matches
+    assert_equal "microsoft/Phi-3-mini-4k-instruct", Candle::LLM.guess_tokenizer("microsoft/Phi-3-mini-4k-instruct-GGUF")
+    
+    # Test pattern matches
+    assert_equal "microsoft/Phi-3-mini-4k-instruct", Candle::LLM.guess_tokenizer("TheBloke/Phi-3-mini-4k-instruct-GGUF")
+    assert_equal "microsoft/phi-2", Candle::LLM.guess_tokenizer("TheBloke/phi-2-GGUF")
+    assert_equal "microsoft/phi-2", Candle::LLM.guess_tokenizer("microsoft/phi-2-GGUF")
+    
+    # Test variations
+    assert_equal "microsoft/Phi-3-medium-4k-instruct", Candle::LLM.guess_tokenizer("Phi-3-medium-GGUF")
+    assert_equal "microsoft/Phi-3-small-8k-instruct", Candle::LLM.guess_tokenizer("Phi-3-small-GGUF")
+  end
+  
+  def test_phi_model_type_detection
+    skip "Requires Phi model download" unless ENV["RUN_FULL_TESTS"]
+    
+    # This would test actual model loading, but requires downloading models
+    # which is expensive. Only run with RUN_FULL_TESTS=1
+    model = Candle::LLM.from_pretrained("microsoft/phi-2")
+    assert_equal "microsoft/phi-2", model.model_name
+    
+    # Test chat template
+    messages = [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "Hello!" }
+    ]
+    
+    prompt = model.apply_chat_template(messages)
+    assert prompt.include?("System:")
+    assert prompt.include?("User:")
+    assert prompt.include?("Assistant:")
+  end
+  
+  def test_phi3_chat_template
+    skip "Requires Phi-3 model download" unless ENV["RUN_FULL_TESTS"]
+    
+    model = Candle::LLM.from_pretrained("microsoft/Phi-3-mini-4k-instruct")
+    messages = [
+      { role: "system", content: "You are a helpful assistant." },
+      { role: "user", content: "What is Ruby?" }
+    ]
+    
+    prompt = model.apply_chat_template(messages)
+    assert prompt.include?("<|system|>")
+    assert prompt.include?("<|user|>")
+    assert prompt.include?("<|assistant|>")
+    assert prompt.include?("<|end|>")
+  end
+  
+  def test_phi_gguf_loading
+    skip "Requires GGUF file" unless ENV["RUN_FULL_TESTS"]
+    
+    # Test GGUF loading with automatic tokenizer detection
+    model = Candle::LLM.from_pretrained("TheBloke/phi-2-GGUF", gguf_file: "phi-2.Q4_K_M.gguf")
+    assert_instance_of Candle::LLM, model
+  end
+end

--- a/test/llm/phi_unit_test.rb
+++ b/test/llm/phi_unit_test.rb
@@ -1,0 +1,82 @@
+require_relative "../test_helper"
+
+class PhiUnitTest < Minitest::Test
+  def test_phi_in_supported_models
+    # Check that Phi is mentioned in error messages for unsupported models
+    error = assert_raises(RuntimeError) do
+      Candle::LLM.from_pretrained("unknown/model-that-doesnt-exist")
+    end
+    
+    assert error.message.include?("Phi"), "Phi should be listed as a supported model type"
+  end
+  
+  def test_phi_tokenizer_patterns
+    test_cases = {
+      # Phi-3 variants
+      "microsoft/Phi-3-mini-128k-instruct-GGUF" => "microsoft/Phi-3-mini-4k-instruct",
+      "microsoft/Phi-3-medium-128k-instruct-GGUF" => "microsoft/Phi-3-medium-4k-instruct",
+      "microsoft/Phi-3-small-128k-instruct-GGUF" => "microsoft/Phi-3-small-8k-instruct",
+      "TheBloke/Phi-3-mini-4k-instruct-GGUF" => "microsoft/Phi-3-mini-4k-instruct",
+      "SomeUser/phi-3-mini-gguf" => "microsoft/Phi-3-mini-4k-instruct",
+      
+      # Phi-2 variants
+      "microsoft/phi-2-GGUF" => "microsoft/phi-2",
+      "TheBloke/phi-2-GGUF" => "microsoft/phi-2",
+      "quantized/phi-2-q4" => "microsoft/phi-2",
+      
+      # Phi-1.5 variants (note: underscore doesn't match \.)
+      "microsoft/phi-1.5-GGUF" => "microsoft/phi-1_5",
+      "TheBloke/phi-1.5-GGUF" => "microsoft/phi-1_5",
+      
+      # Generic phi
+      "some/phi-model-GGUF" => "microsoft/phi-2"
+    }
+    
+    test_cases.each do |input, expected|
+      actual = Candle::LLM.guess_tokenizer(input)
+      assert_equal expected, actual, "Failed for input: #{input}"
+    end
+  end
+  
+  def test_custom_phi_tokenizer_registration
+    # Test registering a custom Phi tokenizer
+    custom_model = "my-org/custom-phi-3-GGUF"
+    custom_tokenizer = "my-org/custom-phi-3-tokenizer"
+    
+    Candle::LLM.register_tokenizer(custom_model, custom_tokenizer)
+    
+    assert_equal custom_tokenizer, Candle::LLM.guess_tokenizer(custom_model)
+    
+    # Test regex pattern registration
+    Candle::LLM.register_tokenizer(/custom-phi-\d+/, "my-org/phi-tokenizer")
+    assert_equal "my-org/phi-tokenizer", Candle::LLM.guess_tokenizer("custom-phi-4-GGUF")
+  end
+  
+  def test_phi_architecture_detection
+    # This tests that Phi models would be detected correctly
+    # by checking the model name patterns used in the Rust code
+    phi_models = [
+      "microsoft/phi-2",
+      "microsoft/Phi-3-mini-4k-instruct",
+      "microsoft/Phi-3-medium-4k-instruct",
+      "microsoft/Phi-3-small-8k-instruct"
+    ]
+    
+    phi_models.each do |model|
+      assert model.downcase.include?("phi"), "Model name should contain 'phi': #{model}"
+    end
+  end
+  
+  def test_phi_gguf_patterns
+    # Test GGUF file naming patterns
+    gguf_patterns = [
+      "phi-2.Q4_K_M.gguf",
+      "phi-3-mini-4k-instruct.Q5_K_S.gguf",
+      "Phi-3-medium-128k.Q8_0.gguf"
+    ]
+    
+    gguf_patterns.each do |pattern|
+      assert pattern.match?(/\.gguf$/i), "Should match GGUF pattern: #{pattern}"
+    end
+  end
+end


### PR DESCRIPTION
Adding support for Phi2 and Phi3 (safetensors and gguf)

```ruby
require 'candle'
device = Candle::Device.metal

# Phi-3 example
llm = Candle::LLM.from_pretrained("microsoft/Phi-3-mini-4k-instruct", device: device)
llm.generate_stream("Question: How big is the earth? Answer: ") { |t| print t };nil

# GGUF example
llm = Candle::LLM.from_pretrained("TheBloke/phi-2-GGUF", gguf_file: "phi-2.Q4_K_M.gguf", device: device)
llm.generate_stream("Question: How big is the earth? Answer: ") { |t| print t };nil
```
